### PR TITLE
Add tab navigation

### DIFF
--- a/PhotoRater/PhotoRankerApp.swift
+++ b/PhotoRater/PhotoRankerApp.swift
@@ -25,7 +25,7 @@ struct PhotoRaterApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
         }
     }
 }

--- a/PhotoRater/Views/MainTabView.swift
+++ b/PhotoRater/Views/MainTabView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            ContentView()
+                .tabItem {
+                    Label("Analyze", systemImage: "magnifyingglass")
+                }
+
+            PricingView()
+                .tabItem {
+                    Label("Credits", systemImage: "bolt.fill")
+                }
+
+            PromoCodeView()
+                .tabItem {
+                    Label("Promo", systemImage: "gift.fill")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+}


### PR DESCRIPTION
## Summary
- add a `MainTabView` with three tabs for analyzing photos, managing credits, and promo codes
- launch the app with `MainTabView`

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_688a5fa4f654833391edee788b8ff5e2