### PR TITLE
Add test for DetailedScores averageScore

### DIFF
--- a/PhotoRater/PhotoRaterTests/PhotoRaterTests.swift
+++ b/PhotoRater/PhotoRaterTests/PhotoRaterTests.swift
@@ -14,4 +14,23 @@ struct PhotoRaterTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
+    /// Ensure that the `averageScore` property correctly computes the mean of
+    /// the component scores.
+    @Test func testDetailedScoresAverage() async throws {
+        // Given a set of known detailed scores
+        let scores = DetailedScores(
+            overall: 0,
+            visualQuality: 80,
+            attractiveness: 70,
+            datingAppeal: 90,
+            swipeWorthiness: 60
+        )
+
+        // When computing the average
+        let expectedAverage = 75.0
+
+        // Then the calculated average should match our expectation
+        #expect(scores.averageScore == expectedAverage)
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a new PhotoRaterTests test that verifies `DetailedScores.averageScore`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a65d079048333b61bccc9499c0226