### PR TITLE
Add Gallery and Account tabs

### DIFF
--- a/PhotoRater/Views/AccountView.swift
+++ b/PhotoRater/Views/AccountView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct AccountView: View {
+    var body: some View {
+        Text("Account")
+            .font(.title)
+            .padding()
+    }
+}
+
+#Preview {
+    AccountView()
+}

--- a/PhotoRater/Views/GalleryView.swift
+++ b/PhotoRater/Views/GalleryView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct GalleryView: View {
+    var body: some View {
+        Text("Gallery")
+            .font(.title)
+            .padding()
+    }
+}
+
+#Preview {
+    GalleryView()
+}

--- a/PhotoRater/Views/MainTabView.swift
+++ b/PhotoRater/Views/MainTabView.swift
@@ -8,14 +8,14 @@ struct MainTabView: View {
                     Label("Analyze", systemImage: "magnifyingglass")
                 }
 
-            PricingView()
+            GalleryView()
                 .tabItem {
-                    Label("Credits", systemImage: "bolt.fill")
+                    Label("Gallery", systemImage: "photo.on.rectangle")
                 }
 
-            PromoCodeView()
+            AccountView()
                 .tabItem {
-                    Label("Promo", systemImage: "gift.fill")
+                    Label("Account", systemImage: "person.crop.circle")
                 }
         }
     }


### PR DESCRIPTION
## Summary
- implement new placeholder views `GalleryView` and `AccountView`
- update `MainTabView` to show `Analyze`, `Gallery`, and `Account` tabs

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688a7428012c8333b67ca492c17c8545