### PR TITLE
Add Gallery and Account views

### DIFF
--- a/PhotoRater/PhotoRankerApp.swift
+++ b/PhotoRater/PhotoRankerApp.swift
@@ -26,6 +26,7 @@ struct PhotoRaterApp: App {
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .responsive()
         }
     }
 }

--- a/PhotoRater/PhotoRater.xcodeproj/project.pbxproj
+++ b/PhotoRater/PhotoRater.xcodeproj/project.pbxproj
@@ -28,9 +28,12 @@
 		AB8032B02DB334890005A7DC /* PhotoTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032AE2DB334850005A7DC /* PhotoTag.swift */; };
 		AB8032C02DB33D0B0005A7DC /* PhotosPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032BF2DB33D020005A7DC /* PhotosPicker.swift */; };
 		AB8032C22DB33D200005A7DC /* CriteriaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032C12DB33D170005A7DC /* CriteriaButton.swift */; };
-               AB8032C42DB33D330005A7DC /* PhotoResultCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032C32DB33D2E0005A7DC /* PhotoResultCard.swift */; };
-               AB8032C62DB33D470005A7DC /* ProcessingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032C52DB33D370005A7DC /* ProcessingOverlay.swift */; };
-               AB9F0A812F1111110005A7DC /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9F0A802F1111110005A7DC /* MainTabView.swift */; };
+                AB8032C42DB33D330005A7DC /* PhotoResultCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032C32DB33D2E0005A7DC /* PhotoResultCard.swift */; };
+                AB8032C62DB33D470005A7DC /* ProcessingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8032C52DB33D370005A7DC /* ProcessingOverlay.swift */; };
+                AB9F0A812F1111110005A7DC /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9F0A802F1111110005A7DC /* MainTabView.swift */; };
+                AB16CEDDB6587523FCF1016B /* GalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB82C4ABEEBD84CBF0AA1EB6 /* GalleryView.swift */; };
+               AB7F6193A7616D0322508231 /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9BF5C86947447786F514F7 /* AccountView.swift */; };
+               AB50C1012FEEFF0011223344 /* ResponsiveModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50C1002FEEFF0011223344 /* ResponsiveModifier.swift */; };
                AB8032D42DB343FC0005A7DC /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = AB8032D32DB343FC0005A7DC /* FirebaseAnalytics */; };
 		AB8032D62DB343FC0005A7DC /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = AB8032D52DB343FC0005A7DC /* FirebaseAnalyticsOnDeviceConversion */; };
 		AB8032D82DB343FC0005A7DC /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = AB8032D72DB343FC0005A7DC /* FirebaseAnalyticsWithoutAdIdSupport */; };
@@ -132,8 +135,11 @@
 		AB8032BF2DB33D020005A7DC /* PhotosPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosPicker.swift; sourceTree = "<group>"; };
 		AB8032C12DB33D170005A7DC /* CriteriaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriteriaButton.swift; sourceTree = "<group>"; };
 		AB8032C32DB33D2E0005A7DC /* PhotoResultCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoResultCard.swift; sourceTree = "<group>"; };
-               AB8032C52DB33D370005A7DC /* ProcessingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingOverlay.swift; sourceTree = "<group>"; };
-               AB9F0A802F1111110005A7DC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+                AB8032C52DB33D370005A7DC /* ProcessingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingOverlay.swift; sourceTree = "<group>"; };
+                AB9F0A802F1111110005A7DC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+                AB82C4ABEEBD84CBF0AA1EB6 /* GalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryView.swift; sourceTree = "<group>"; };
+               AB9BF5C86947447786F514F7 /* AccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
+               AB50C1002FEEFF0011223344 /* ResponsiveModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsiveModifier.swift; sourceTree = "<group>"; };
                AB8032C82DB33DC10005A7DC /* PhotoProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoProcessor.swift; sourceTree = "<group>"; };
 		AB8032CA2DB33DDD0005A7DC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = text; path = Assets.xcassets; sourceTree = "<group>"; };
 		ABFDC0CE2E3306FD0074935A /* PhotoRankerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRankerApp.swift; sourceTree = "<group>"; };
@@ -296,6 +302,8 @@
 			isa = PBXGroup;
 			children = (
                                AB80327D2DB18F4A0005A7DC /* ContentView.swift */,
+                               AB82C4ABEEBD84CBF0AA1EB6 /* GalleryView.swift */,
+                               AB9BF5C86947447786F514F7 /* AccountView.swift */,
                                AB496BEF2DDF085600B87CA6 /* PricingView.swift */,
                                AB6C60C12E37E497005FAD8A /* PromoCodeView.swift */,
                                AB9F0A802F1111110005A7DC /* MainTabView.swift */,
@@ -310,12 +318,13 @@
 				AB496BE72DDEF2AA00B87CA6 /* PhotoDetailView.swift */,
 				AB8032BF2DB33D020005A7DC /* PhotosPicker.swift */,
 				AB8032C12DB33D170005A7DC /* CriteriaButton.swift */,
-				AB8032C32DB33D2E0005A7DC /* PhotoResultCard.swift */,
-				AB8032C52DB33D370005A7DC /* ProcessingOverlay.swift */,
-			);
-			path = Components;
-			sourceTree = "<group>";
-		};
+                               AB8032C32DB33D2E0005A7DC /* PhotoResultCard.swift */,
+                               AB8032C52DB33D370005A7DC /* ProcessingOverlay.swift */,
+                               AB50C1002FEEFF0011223344 /* ResponsiveModifier.swift */,
+                       );
+                       path = Components;
+                       sourceTree = "<group>";
+               };
 		AB8032C72DB33DB60005A7DC /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -615,9 +624,12 @@
                                ABFDC0CF2E3306FD0074935A /* PhotoRankerApp.swift in Sources */,
                                AB80327E2DB18F4A0005A7DC /* ContentView.swift in Sources */,
                                AB9F0A812F1111110005A7DC /* MainTabView.swift in Sources */,
+                               AB16CEDDB6587523FCF1016B /* GalleryView.swift in Sources */,
+                               AB7F6193A7616D0322508231 /* AccountView.swift in Sources */,
+                               AB50C1012FEEFF0011223344 /* ResponsiveModifier.swift in Sources */,
                        );
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                       runOnlyForDeploymentPostprocessing = 0;
+               };
 		AB8032842DB18F4C0005A7DC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/PhotoRater/Views/Components/ResponsiveModifier.swift
+++ b/PhotoRater/Views/Components/ResponsiveModifier.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Scales the contained view based on screen width for better phone and iPad support.
+struct ResponsiveModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        GeometryReader { geometry in
+            // Use iPhone 15 Pro width as baseline (390pt)
+            let scale = max(min(geometry.size.width / 390, 1.4), 0.8)
+            content
+                .scaleEffect(scale)
+                .frame(width: geometry.size.width,
+                       height: geometry.size.height,
+                       alignment: .top)
+        }
+    }
+}
+
+extension View {
+    /// Apply a scaling effect that adjusts automatically according to the
+    /// available horizontal screen size.
+    func responsive() -> some View {
+        modifier(ResponsiveModifier())
+    }
+}


### PR DESCRIPTION
## Summary
- include `GalleryView.swift` and `AccountView.swift` in project file
- compile the two new view files in main app target
- scale interface for varying device widths via new `ResponsiveModifier`

## Testing
- `npm test` *(fails: package.json missing)*
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688a872655c08333b2e59bbeca800416