### PR TITLE
Improve view scaling

### DIFF
--- a/PhotoRater/Views/Components/DeviceSizing.swift
+++ b/PhotoRater/Views/Components/DeviceSizing.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// Utility for scaling UI elements relative to the device's screen width.
+struct DeviceSizing {
+    /// Returns a scale factor based on the current screen width
+    /// compared to a reference width of 390pt (iPhone 14 Pro).
+    static var scale: CGFloat {
+        let width = UIScreen.main.bounds.width
+        return max(0.8, min(width / 390, 1.5))
+    }
+}

--- a/PhotoRater/Views/Components/PhotoDetailView.swift
+++ b/PhotoRater/Views/Components/PhotoDetailView.swift
@@ -82,13 +82,13 @@ struct PhotoDetailView: View {
             } else {
                 Rectangle()
                     .fill(Color.gray.opacity(0.3))
-                    .frame(height: 250)
+                    .frame(height: 250 * DeviceSizing.scale)
                     .overlay(
                         ProgressView()
                     )
             }
         }
-        .frame(maxHeight: 300)
+        .frame(maxHeight: 300 * DeviceSizing.scale)
         .cornerRadius(12)
     }
     
@@ -364,12 +364,12 @@ struct QualityIndicator: View {
         ZStack {
             Circle()
                 .stroke(Color.gray.opacity(0.3), lineWidth: 8)
-                .frame(width: 60, height: 60)
+                .frame(width: 60 * DeviceSizing.scale, height: 60 * DeviceSizing.scale)
             
             Circle()
                 .trim(from: 0, to: score / 100)
                 .stroke(getQualityColor(score), style: StrokeStyle(lineWidth: 8, lineCap: .round))
-                .frame(width: 60, height: 60)
+                .frame(width: 60 * DeviceSizing.scale, height: 60 * DeviceSizing.scale)
                 .rotationEffect(.degrees(-90))
             
             Image(systemName: getQualityIcon(score))

--- a/PhotoRater/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater/Views/Components/PhotoResultCard.swift
@@ -173,7 +173,7 @@ struct PhotoResultCard: View {
                     .scaledToFill()
             } else if isLoading {
                 ProgressView()
-                    .frame(height: 180)
+                    .frame(height: 180 * DeviceSizing.scale)
             } else {
                 Rectangle()
                     .fill(Color.gray.opacity(0.3))
@@ -184,7 +184,7 @@ struct PhotoResultCard: View {
                     )
             }
         }
-        .frame(height: 180)
+        .frame(height: 180 * DeviceSizing.scale)
         .clipped()
         .cornerRadius(12)
     }

--- a/PhotoRater/Views/Components/ProcessingOverlay.swift
+++ b/PhotoRater/Views/Components/ProcessingOverlay.swift
@@ -21,7 +21,7 @@ struct ProcessingOverlay: View {
             if let progress = progress {
                 ProgressView(value: progress)
                     .progressViewStyle(LinearProgressViewStyle(tint: .blue))
-                    .frame(width: 200)
+                    .frame(width: 200 * DeviceSizing.scale)
             }
         }
         .padding(30)

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -25,7 +25,8 @@ struct ContentView: View {
     @StateObject private var pricingManager = PricingManager.shared
     
     var body: some View {
-        NavigationView {
+        let scale = DeviceSizing.scale
+        return NavigationView {
             ScrollView {
                 VStack(spacing: 20) {
                     titleAndCreditsSection
@@ -238,7 +239,7 @@ struct ContentView: View {
             }
             .foregroundColor(.blue)
             .frame(maxWidth: .infinity)
-            .frame(height: 120)
+            .frame(height: 120 * scale)
             .background(Color.blue.opacity(0.1))
             .cornerRadius(12)
             .overlay(
@@ -563,7 +564,7 @@ struct CriteriaCard: View {
             .padding(.vertical, 12)
             .padding(.horizontal, 8)
             .frame(maxWidth: .infinity)
-            .frame(height: 80)
+            .frame(height: 80 * DeviceSizing.scale)
             .background(
                 RoundedRectangle(cornerRadius: 10)
                     .fill(isSelected ? Color.blue : Color(.systemGray6))


### PR DESCRIPTION
## Summary
- add DeviceSizing helper for scaling
- scale photo picker, result cards, and overlays
- adjust detail view graphic sizes
- adapt criteria cards

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_688a8c7a27688333bf866cef74757d13