### PR TITLE
Improve result card layout

### DIFF
--- a/PhotoRater/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater/Views/Components/PhotoResultCard.swift
@@ -2,15 +2,18 @@ import SwiftUI
 
 struct PhotoResultCard: View {
     let rankedPhoto: RankedPhoto
+    /// Width of the card used to determine responsive sizing
+    let cardWidth: CGFloat
     @State private var isLoading = true
     @State private var loadedImage: UIImage?
     @State private var showingDetailView = false
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let imageHeight = cardWidth * 0.55
+        return VStack(alignment: .leading, spacing: 8) {
             // Photo display with quality indicator instead of score
             ZStack(alignment: .topTrailing) {
-                photoImageView
+                photoImageView(height: imageHeight)
                 
                 // Quality badge instead of numerical score
                 VStack(spacing: 2) {
@@ -161,7 +164,7 @@ struct PhotoResultCard: View {
         }
     }
     
-    private var photoImageView: some View {
+    private func photoImageView(height: CGFloat) -> some View {
         Group {
             if let localImage = rankedPhoto.localImage {
                 Image(uiImage: localImage)
@@ -173,7 +176,6 @@ struct PhotoResultCard: View {
                     .scaledToFill()
             } else if isLoading {
                 ProgressView()
-                    .frame(height: 180)
             } else {
                 Rectangle()
                     .fill(Color.gray.opacity(0.3))
@@ -184,7 +186,7 @@ struct PhotoResultCard: View {
                     )
             }
         }
-        .frame(height: 180)
+        .frame(height: height)
         .clipped()
         .cornerRadius(12)
     }

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -359,12 +359,16 @@ struct ContentView: View {
     }
     
     private var resultsPhotoCards: some View {
-        VStack(spacing: 16) {
-            ForEach(rankedPhotos) { photo in
-                PhotoResultCard(rankedPhoto: photo)
+        GeometryReader { proxy in
+            let cardWidth = proxy.size.width - 32
+            VStack(spacing: 16) {
+                ForEach(rankedPhotos) { photo in
+                    PhotoResultCard(rankedPhoto: photo, cardWidth: cardWidth)
+                }
             }
+            .padding(.horizontal)
+            .frame(width: proxy.size.width)
         }
-        .padding(.horizontal)
     }
     
     @ViewBuilder

--- a/PhotoRater_backup/Views/ContentView.swift
+++ b/PhotoRater_backup/Views/ContentView.swift
@@ -269,11 +269,15 @@ struct ContentView: View {
                             }
                             
                             // Single column of photo cards
-                            VStack(spacing: 16) {
-                                ForEach(rankedPhotos) { photo in
-                                    PhotoResultCard(rankedPhoto: photo)
-                                        .padding(.horizontal)
+                            GeometryReader { proxy in
+                                let cardWidth = proxy.size.width - 32
+                                VStack(spacing: 16) {
+                                    ForEach(rankedPhotos) { photo in
+                                        PhotoResultCard(rankedPhoto: photo, cardWidth: cardWidth)
+                                            .padding(.horizontal)
+                                    }
                                 }
+                                .frame(width: proxy.size.width)
                             }
                         }
                         .padding(.bottom, 20)


### PR DESCRIPTION
## Summary
- update `PhotoResultCard` to size images relative to card width
- determine card width in `ContentView` using `GeometryReader`
- keep backup copy in sync

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a632f624c8333af2a9eda7e1d418c