### PR TITLE
Add simple gallery and account features

### DIFF
--- a/PhotoRater/Models/RankedPhoto.swift
+++ b/PhotoRater/Models/RankedPhoto.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-struct RankedPhoto: Identifiable {
+struct RankedPhoto: Identifiable, Codable {
     let id: UUID
     let fileName: String
     let storageURL: String?
@@ -18,6 +18,21 @@ struct RankedPhoto: Identifiable {
     let nextPhotoSuggestions: [String]?
     
     var localImage: UIImage?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case fileName
+        case storageURL
+        case score
+        case tags
+        case reason
+        case detailedScores
+        case technicalFeedback
+        case datingInsights
+        case improvements
+        case strengths
+        case nextPhotoSuggestions
+    }
     
     // Simple initializer for backward compatibility
     init(image: UIImage, score: Double, tags: [PhotoTag]?, reason: String? = nil) {
@@ -80,6 +95,40 @@ struct RankedPhoto: Identifiable {
             strengths: self.strengths,
             nextPhotoSuggestions: self.nextPhotoSuggestions
         )
+    }
+
+    // Codable conformance (excluding localImage)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        fileName = try container.decode(String.self, forKey: .fileName)
+        storageURL = try container.decodeIfPresent(String.self, forKey: .storageURL)
+        score = try container.decode(Double.self, forKey: .score)
+        tags = try container.decodeIfPresent([PhotoTag].self, forKey: .tags)
+        reason = try container.decodeIfPresent(String.self, forKey: .reason)
+        detailedScores = try container.decodeIfPresent(DetailedScores.self, forKey: .detailedScores)
+        technicalFeedback = try container.decodeIfPresent(TechnicalFeedback.self, forKey: .technicalFeedback)
+        datingInsights = try container.decodeIfPresent(DatingInsights.self, forKey: .datingInsights)
+        improvements = try container.decodeIfPresent([String].self, forKey: .improvements)
+        strengths = try container.decodeIfPresent([String].self, forKey: .strengths)
+        nextPhotoSuggestions = try container.decodeIfPresent([String].self, forKey: .nextPhotoSuggestions)
+        localImage = nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(fileName, forKey: .fileName)
+        try container.encodeIfPresent(storageURL, forKey: .storageURL)
+        try container.encode(score, forKey: .score)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(reason, forKey: .reason)
+        try container.encodeIfPresent(detailedScores, forKey: .detailedScores)
+        try container.encodeIfPresent(technicalFeedback, forKey: .technicalFeedback)
+        try container.encodeIfPresent(datingInsights, forKey: .datingInsights)
+        try container.encodeIfPresent(improvements, forKey: .improvements)
+        try container.encodeIfPresent(strengths, forKey: .strengths)
+        try container.encodeIfPresent(nextPhotoSuggestions, forKey: .nextPhotoSuggestions)
     }
 }
 

--- a/PhotoRater/Services/GalleryManager.swift
+++ b/PhotoRater/Services/GalleryManager.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class GalleryManager: ObservableObject {
+    static let shared = GalleryManager()
+
+    @Published private(set) var photos: [RankedPhoto] = []
+
+    private let saveURL: URL = {
+        let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return path.appendingPathComponent("gallery.json")
+    }()
+
+    private init() {
+        load()
+    }
+
+    func add(_ newPhotos: [RankedPhoto]) {
+        photos.insert(contentsOf: newPhotos, at: 0)
+        save()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: saveURL) else { return }
+        do {
+            photos = try JSONDecoder().decode([RankedPhoto].self, from: data)
+        } catch {
+            print("Failed to load gallery: \(error)")
+        }
+    }
+
+    private func save() {
+        do {
+            let data = try JSONEncoder().encode(photos)
+            try data.write(to: saveURL)
+        } catch {
+            print("Failed to save gallery: \(error)")
+        }
+    }
+}

--- a/PhotoRater/Views/AccountView.swift
+++ b/PhotoRater/Views/AccountView.swift
@@ -1,10 +1,44 @@
 import SwiftUI
+import FirebaseAuth
 
 struct AccountView: View {
+    @StateObject private var pricingManager = PricingManager.shared
+
     var body: some View {
-        Text("Account")
-            .font(.title)
-            .padding()
+        NavigationView {
+            Form {
+                Section(header: Text("Account")) {
+                    if let user = AuthenticationService.shared.currentUser {
+                        Text("User ID: \(user.uid)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Section(header: Text("Credits")) {
+                    if pricingManager.isInitialized {
+                        HStack {
+                            Text(pricingManager.isUnlimited ? "Unlimited" : "Credits")
+                            Spacer()
+                            Text(pricingManager.isUnlimited ? "∞" : "\(pricingManager.userCredits)")
+                                .foregroundColor(pricingManager.isUnlimited ? .green : .primary)
+                        }
+                    } else {
+                        ProgressView()
+                    }
+                    Button("Restore Purchases") {
+                        Task { await pricingManager.restorePurchases() }
+                    }
+                }
+
+                Section {
+                    Button("Sign Out") {
+                        try? Auth.auth().signOut()
+                    }
+                }
+            }
+            .navigationTitle("Account")
+        }
     }
 }
 

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @State private var alertMessage = ""
     
     @StateObject private var pricingManager = PricingManager.shared
+    @StateObject private var galleryManager = GalleryManager.shared
     
     var body: some View {
         let scale = DeviceSizing.scale
@@ -527,6 +528,7 @@ struct ContentView: View {
                     self.rankedPhotos = rankedPhotos
                     self.isProcessing = false
                     pricingManager.deductCredits(count: selectedImages.count)
+                    galleryManager.add(rankedPhotos)
                 }
             case .failure(let error):
                 Task { @MainActor in

--- a/PhotoRater/Views/GalleryView.swift
+++ b/PhotoRater/Views/GalleryView.swift
@@ -1,10 +1,30 @@
 import SwiftUI
 
 struct GalleryView: View {
+    @StateObject private var galleryManager = GalleryManager.shared
+
+    private let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
     var body: some View {
-        Text("Gallery")
-            .font(.title)
-            .padding()
+        NavigationView {
+            Group {
+                if galleryManager.photos.isEmpty {
+                    Text("No analyzed photos yet")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else {
+                    ScrollView {
+                        LazyVGrid(columns: columns, spacing: 16) {
+                            ForEach(galleryManager.photos) { photo in
+                                PhotoResultCard(rankedPhoto: photo)
+                            }
+                        }
+                        .padding()
+                    }
+                }
+            }
+            .navigationTitle("Gallery")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- persist analysis results in a new `GalleryManager`
- adopt `Codable` for `RankedPhoto` to support saving
- store completed analyses to the gallery from `ContentView`
- display saved photos in a new `GalleryView`
- expand `AccountView` with credits info and sign‑out option

## Testing
- `swift test --package-path Firebase`

------
https://chatgpt.com/codex/tasks/task_e_688a9109ae888333a38d56ecb9f63355