### PR TITLE
Fix ternary syntax in PhotoProcessor

### DIFF
--- a/PhotoRater/Services/PhotoProcessor.swift
+++ b/PhotoRater/Services/PhotoProcessor.swift
@@ -498,7 +498,7 @@ class PhotoProcessor: ObservableObject {
                     let balancedPhoto = photo.withUpdatedReason(updatedReason)
                     selected.append(balancedPhoto)
                     
-                    print("Added \(category == "general" ? "general") category (score: \(photo.score))")
+                    print("Added \(category == \"general\" ? \"general\" : category) category (score: \(photo.score))")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix a print statement in `PhotoProcessor.swift` so the ternary operator has a default branch

## Testing
- `swiftc -typecheck PhotoRater/Services/PhotoProcessor.swift` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_688ab9143ea48333aabdc925a3b1c4c7