### PR TITLE
Fix Cloud Run start failure

### DIFF
--- a/PhotoRater/functions/package-lock.json
+++ b/PhotoRater/functions/package-lock.json
@@ -15,7 +15,7 @@
         "firebase-functions-test": "^3.1.0"
       },
       "engines": {
-        "node": "22"
+        "node": "20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/PhotoRater/functions/package.json
+++ b/PhotoRater/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- specify Node 20 runtime for Firebase Functions

This change fixes container startup errors when deploying the `analyzePhotos` Cloud Function.

## Testing
- `npm install --silent`

------
https://chatgpt.com/codex/tasks/task_e_688abb99244c833393e97ea1e09f2f5d