### PR TITLE
Fix Cloud Functions runtime version

### DIFF
--- a/PhotoRater/functions/package-lock.json
+++ b/PhotoRater/functions/package-lock.json
@@ -15,7 +15,7 @@
         "firebase-functions-test": "^3.1.0"
       },
       "engines": {
-        "node": "22"
+        "node": "20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/PhotoRater/functions/package.json
+++ b/PhotoRater/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- use Node 20 runtime for Firebase functions

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688abbd2793083339e20418c7f3d4b4d