### PR TITLE
Fix quoting bug in PhotoProcessor

### DIFF
--- a/PhotoRater/Services/PhotoProcessor.swift
+++ b/PhotoRater/Services/PhotoProcessor.swift
@@ -498,7 +498,7 @@ class PhotoProcessor: ObservableObject {
                     let balancedPhoto = photo.withUpdatedReason(updatedReason)
                     selected.append(balancedPhoto)
                     
-                    print("Added \(category == \"general\" ? \"general\" : category) category (score: \(photo.score))")
+                    print("Added \(category == "general" ? "general" : category) category (score: \(photo.score))")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix unterminated string literal in PhotoProcessor.swift

## Testing
- `swiftc PhotoRater/Services/PhotoProcessor.swift -o /tmp/PhotoProcessor` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_688abc0091e48333863d71403efa0d54