### PR TITLE
Fix Firebase delegate and simulator App Check

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import FirebaseCore
 import FirebaseAuth
+import FirebaseAppCheck
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     private var authStateListener: AuthStateDidChangeListenerHandle?
@@ -8,6 +9,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Configure Firebase
         FirebaseApp.configure()
+#if targetEnvironment(simulator)
+        // Use a debug provider when running in the simulator to avoid
+        // DeviceCheck errors during development.
+        AppCheck.setAppCheckProviderFactory(DebugAppCheckProviderFactory())
+#endif
         
         // Set up authentication state listener
         authStateListener = Auth.auth().addStateDidChangeListener { auth, user in

--- a/PhotoRater/PhotoRankerApp.swift
+++ b/PhotoRater/PhotoRankerApp.swift
@@ -6,11 +6,10 @@ import Firebase
 
 @main
 struct PhotoRaterApp: App {
-    
-    init() {
-        // Configure Firebase
-        FirebaseApp.configure()
-    }
+
+    /// Register the ``AppDelegate`` to handle Firebase setup and other app
+    /// lifecycle events.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
## Summary
- register the AppDelegate so Firebase can swizzle application methods
- use `DebugAppCheckProviderFactory` in the simulator to avoid DeviceCheck errors

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ad4b0cc50833383f694f49c64729e