### PR TITLE
Fix DebugAppCheckProviderFactory error

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -9,10 +9,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Configure Firebase
         FirebaseApp.configure()
-#if targetEnvironment(simulator)
-        // Use a debug provider when running in the simulator to avoid
-        // DeviceCheck errors during development.
-        AppCheck.setAppCheckProviderFactory(DebugAppCheckProviderFactory())
+#if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
+        // Use a debug provider on platforms that don't support DeviceCheck,
+        // such as the iOS simulator and macOS Catalyst.
+        AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())
 #endif
         
         // Set up authentication state listener


### PR DESCRIPTION
## Summary
- enable AppCheck debug provider when running on macOS Catalyst or the iOS simulator

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688adae4ffd883338814272bb6681f47