### PR TITLE
Fix AppCheck provider selection on macOS

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -9,9 +9,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Configure Firebase
         FirebaseApp.configure()
-#if targetEnvironment(simulator)
-        // Use a debug provider when running in the simulator to avoid
-        // DeviceCheck errors during development.
+#if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
+        // Use a debug provider when running in the simulator or Mac Catalyst to
+        // avoid DeviceCheck errors during development.
         AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())
 #endif
         


### PR DESCRIPTION
## Summary
- ensure Firebase App Check uses debug provider on Mac Catalyst

## Testing
- `npm test` *(fails: Missing script)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ae63bc4048333a2f01c199d8192d2