### PR TITLE
Fix purchase restoration

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 // Initialize user credits after authentication
                 Task {
                     await PricingManager.shared.loadUserCredits()
+                    await PricingManager.shared.restorePurchases()
                 }
             } else {
                 print("🔑 No user authenticated, signing in anonymously...")
@@ -34,6 +35,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                         // Initialize user credits after authentication
                         Task {
                             await PricingManager.shared.loadUserCredits()
+                            await PricingManager.shared.restorePurchases()
                         }
                     }
                 }

--- a/PhotoRater/Services/PricingManager.swift
+++ b/PhotoRater/Services/PricingManager.swift
@@ -18,6 +18,57 @@ class PricingManager: ObservableObject {
     
     static let shared = PricingManager()
     private var updateListenerTask: Task<Void, Error>?
+
+    // MARK: - Product Metadata
+
+    /// The available pricing tiers for in-app purchases
+    enum PricingTier {
+        case starter       // $0.99 for 20 photos
+        case value         // $4.99 for 120 photos
+
+        var credits: Int {
+            switch self {
+            case .starter: return 20
+            case .value: return 120
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .starter: return "Starter Pack"
+            case .value: return "Best Value"
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .starter: return "Great for optimizing your profile"
+            case .value: return "Best deal - analyze your entire photo collection"
+            }
+        }
+
+        var savings: String? {
+            switch self {
+            case .value: return "Save 16%"
+            default: return nil
+            }
+        }
+
+        var isUnlimited: Bool { false }
+    }
+
+    /// StoreKit product identifiers
+    enum ProductID: String, CaseIterable {
+        case starter = "com.photorater.starter20"
+        case value = "com.photorater.value120"
+
+        var tier: PricingTier {
+            switch self {
+            case .starter: return .starter
+            case .value: return .value
+            }
+        }
+    }
     
     // Launch promotion check
     var isLaunchPeriod: Bool {
@@ -55,9 +106,11 @@ class PricingManager: ObservableObject {
             for await result in Transaction.all {
                 do {
                     let transaction = try checkVerified(result)
-                    
-                    // Only count non-refunded transactions
-                    guard !transaction.isUpgraded else { continue }
+
+                    // Skip transactions that were revoked or refunded
+                    if let _ = transaction.revocationDate {
+                        continue
+                    }
                     
                     if let productID = ProductID(rawValue: transaction.productID) {
                         if productID.tier.isUnlimited {
@@ -324,13 +377,6 @@ class PricingManager: ObservableObject {
     
     deinit {
         updateListenerTask?.cancel()
-    }
-}
-
-// MARK: - Product Tier Extensions
-extension ProductTier {
-    var isUnlimited: Bool {
-        return self == .unlimited
     }
 }
 


### PR DESCRIPTION
## Summary
- restore Apple purchases after sign in
- ignore revoked transactions when rebuilding purchase state
- reintroduce missing ProductID enum

## Testing
- `swift test --list-tests`

------
https://chatgpt.com/codex/tasks/task_e_688afe0b2c2483339e75229102389360