### PR TITLE
Add content moderation service

### DIFF
--- a/PhotoRater/Services/ContentModerationService.swift
+++ b/PhotoRater/Services/ContentModerationService.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+struct ContentModerationResult {
+    let isAllowed: Bool
+    let errorMessage: String?
+}
+
+class ContentModerationService {
+    static let shared = ContentModerationService()
+    private init() {}
+    private let minSize: CGFloat = 100
+    private let maxFileSize = 10 * 1024 * 1024 // 10MB
+
+    func validateImageContent(image: UIImage) -> Bool {
+        let result = detectInappropriateContent(image: image)
+        return result.isAllowed
+    }
+
+    func detectInappropriateContent(image: UIImage) -> ContentModerationResult {
+        let size = image.size
+        if size.width < minSize || size.height < minSize {
+            return ContentModerationResult(isAllowed: false,
+                                           errorMessage: "Image dimensions must be at least 100x100 pixels")
+        }
+
+        guard image.pngData() != nil || image.jpegData(compressionQuality: 1.0) != nil else {
+            return ContentModerationResult(isAllowed: false,
+                                           errorMessage: "Unsupported image format")
+        }
+
+        if let data = image.jpegData(compressionQuality: 1.0), data.count > maxFileSize {
+            return ContentModerationResult(isAllowed: false,
+                                           errorMessage: "Image file size exceeds 10MB limit")
+        }
+
+        return ContentModerationResult(isAllowed: true, errorMessage: nil)
+    }
+
+    func blockSensitiveContent(images: [UIImage]) -> [UIImage] {
+        return images.filter { detectInappropriateContent(image: $0).isAllowed }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `ContentModerationService` with dimension, format and file-size checks
- validate images with content moderation before uploading in `PhotoProcessor`
- add missing import

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688b01e09d5c833395b919d1b9c77a76