### PR TITLE
Add privacy policy system

### DIFF
--- a/PhotoRater/Services/PrivacyPolicyManager.swift
+++ b/PhotoRater/Services/PrivacyPolicyManager.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+class PrivacyPolicyManager {
+    static let shared = PrivacyPolicyManager()
+
+    private let acceptedKey = "PrivacyPolicyAcceptedVersion"
+    private let currentVersion = 1
+
+    private init() {}
+
+    func hasAcceptedPrivacyPolicy() -> Bool {
+        UserDefaults.standard.integer(forKey: acceptedKey) >= currentVersion
+    }
+
+    func acceptPrivacyPolicy() {
+        UserDefaults.standard.set(currentVersion, forKey: acceptedKey)
+    }
+
+    func showPrivacyPolicy() -> Bool {
+        !hasAcceptedPrivacyPolicy()
+    }
+}

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var showingImagePicker = false
     @State private var showingPricingView = false
     @State private var showingPromoCodeView = false
+    @State private var showingPrivacyPolicy = false
     @State private var errorMessage: String? = nil
     @State private var showingAlert = false
     @State private var alertMessage = ""
@@ -49,6 +50,9 @@ struct ContentView: View {
             .sheet(isPresented: $showingPromoCodeView) {
                 PromoCodeView()
             }
+            .sheet(isPresented: $showingPrivacyPolicy) {
+                PrivacyPolicyView()
+            }
             .alert("Error", isPresented: $showingAlert) {
                 Button("OK") {
                     errorMessage = nil
@@ -60,6 +64,9 @@ struct ContentView: View {
             .onAppear {
                 Task {
                     await pricingManager.loadUserCredits()
+                }
+                if PrivacyPolicyManager.shared.showPrivacyPolicy() {
+                    showingPrivacyPolicy = true
                 }
             }
         }

--- a/PhotoRater/Views/PricingView.swift
+++ b/PhotoRater/Views/PricingView.swift
@@ -10,6 +10,7 @@ struct PricingView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var selectedProductID: PricingManager.ProductID = .starter
     @State private var showingPromoCodeView = false
+    @State private var showingPrivacyPolicy = false
     
     var body: some View {
         NavigationView {
@@ -153,7 +154,13 @@ struct PricingView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .multilineTextAlignment(.center)
-                        
+
+                        Button("Privacy Policy") {
+                            showingPrivacyPolicy = true
+                        }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+
                         if isLaunchPeriod {
                             Text("Launch promotion valid through August 24, 2025")
                                 .font(.caption)
@@ -175,6 +182,9 @@ struct PricingView: View {
         .navigationViewStyle(.stack)
         .sheet(isPresented: $showingPromoCodeView) {
             PromoCodeView()
+        }
+        .sheet(isPresented: $showingPrivacyPolicy) {
+            PrivacyPolicyView()
         }
         .onAppear {
             // Products are automatically loaded in PricingManager.init()

--- a/PhotoRater/Views/PrivacyPolicyView.swift
+++ b/PhotoRater/Views/PrivacyPolicyView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    SectionHeader("Data Collection")
+                    Text("We only collect the photos you choose to analyze along with minimal usage metadata. No personal information is required to use PhotoRater.")
+                        .font(.body)
+
+                    SectionHeader("Photo Processing")
+                    Text("Your photos are processed using our AI models to generate rankings and recommendations. Processing may occur on device or on secure servers.")
+                        .font(.body)
+
+                    SectionHeader("Storage")
+                    Text("Photos and analysis results are temporarily stored in Firebase to sync across your devices. Data is retained for up to 30 days then automatically deleted.")
+                        .font(.body)
+
+                    SectionHeader("Sharing")
+                    Text("We do not sell or share your photos or personal data with any third parties. Data is used solely to provide the app's core functionality.")
+                        .font(.body)
+
+                    SectionHeader("User Rights")
+                    Text("You may request deletion of your stored photos at any time from the account screen. For any privacy questions contact us at support@photorater.app.")
+                        .font(.body)
+                }
+                .padding()
+            }
+            .navigationTitle("Privacy Policy")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Decline") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Accept") {
+                        PrivacyPolicyManager.shared.acceptPrivacyPolicy()
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    @ViewBuilder
+    private func SectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.headline)
+            .padding(.top)
+    }
+}
+
+#Preview {
+    PrivacyPolicyView()
+}


### PR DESCRIPTION
## Summary
- add PrivacyPolicyView with policy sections and Accept/Decline actions
- track policy acceptance in PrivacyPolicyManager
- show privacy policy on first launch in ContentView
- link to privacy policy from PricingView

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_688b01e891f08333b09f0ca0bb0bb1ba