### PR TITLE
Add Terms of Service flow

### DIFF
--- a/PhotoRater/Services/TermsOfServiceManager.swift
+++ b/PhotoRater/Services/TermsOfServiceManager.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+class TermsOfServiceManager {
+    static let shared = TermsOfServiceManager()
+
+    /// Increment this value whenever the terms text changes to force users to re-accept.
+    private let currentVersion = 1
+    private let acceptedKey = "AcceptedTermsVersion"
+    private let defaults = UserDefaults.standard
+
+    private init() {}
+
+    /// Returns true if the user has accepted the current version of the terms.
+    func hasAcceptedTerms() -> Bool {
+        return defaults.integer(forKey: acceptedKey) >= currentVersion
+    }
+
+    /// Records acceptance of the current terms.
+    func acceptTerms() {
+        defaults.set(currentVersion, forKey: acceptedKey)
+    }
+
+    /// Returns the version of the terms the user previously accepted.
+    func getTermsVersion() -> Int {
+        return defaults.integer(forKey: acceptedKey)
+    }
+}

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var showingImagePicker = false
     @State private var showingPricingView = false
     @State private var showingPromoCodeView = false
+    @State private var showingTermsOfService = false
     @State private var errorMessage: String? = nil
     @State private var showingAlert = false
     @State private var alertMessage = ""
@@ -48,6 +49,13 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showingPromoCodeView) {
                 PromoCodeView()
+            }
+            .sheet(isPresented: $showingTermsOfService) {
+                TermsOfServiceView {
+                    TermsOfServiceManager.shared.acceptTerms()
+                    showingTermsOfService = false
+                    analyzePhotos()
+                }
             }
             .alert("Error", isPresented: $showingAlert) {
                 Button("OK") {
@@ -472,6 +480,11 @@ struct ContentView: View {
     }
     
     private func analyzePhotos() {
+        guard TermsOfServiceManager.shared.hasAcceptedTerms() else {
+            showingTermsOfService = true
+            return
+        }
+
         guard !selectedImages.isEmpty,
               pricingManager.canAnalyzePhotos(count: selectedImages.count) else {
             alertMessage = "You need more credits to analyze these photos."

--- a/PhotoRater/Views/PricingView.swift
+++ b/PhotoRater/Views/PricingView.swift
@@ -10,6 +10,7 @@ struct PricingView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var selectedProductID: PricingManager.ProductID = .starter
     @State private var showingPromoCodeView = false
+    @State private var showingTerms = false
     
     var body: some View {
         NavigationView {
@@ -149,10 +150,16 @@ struct PricingView: View {
                     
                     // Terms and disclaimer
                     VStack(spacing: 8) {
-                        Text("By purchasing, you agree to our Terms of Service")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
+                        HStack(spacing: 4) {
+                            Text("By purchasing, you agree to our")
+                            Button("Terms of Service") {
+                                showingTerms = true
+                            }
+                            .underline()
+                        }
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
                         
                         if isLaunchPeriod {
                             Text("Launch promotion valid through August 24, 2025")
@@ -175,6 +182,9 @@ struct PricingView: View {
         .navigationViewStyle(.stack)
         .sheet(isPresented: $showingPromoCodeView) {
             PromoCodeView()
+        }
+        .sheet(isPresented: $showingTerms) {
+            TermsOfServiceView()
         }
         .onAppear {
             // Products are automatically loaded in PricingManager.init()

--- a/PhotoRater/Views/TermsOfServiceView.swift
+++ b/PhotoRater/Views/TermsOfServiceView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct TermsOfServiceView: View {
+    var onAccept: () -> Void = {}
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Service Description")
+                            .font(.headline)
+                        Text("PhotoRater provides AI-based recommendations on the quality and dating profile suitability of your photos. Results are generated automatically and may not always be accurate.")
+                        Text("User Obligations")
+                            .font(.headline)
+                        Text("You agree to use PhotoRater responsibly and only upload photos that you own or have permission to use. Users must be at least 17 years old.")
+                        Text("Prohibited Content")
+                            .font(.headline)
+                        Text("Uploading inappropriate, explicit, or illegal images is strictly forbidden and will result in immediate account termination.")
+                        Text("Payments")
+                            .font(.headline)
+                        Text("Subscriptions and credit purchases are processed through Apple. All sales are final and subject to Apple's terms.")
+                        Text("Liability")
+                            .font(.headline)
+                        Text("PhotoRater's AI analysis is provided \"as is\" without warranty of accuracy. We are not liable for any actions taken based on the recommendations.")
+                    }
+                    .padding()
+                }
+
+                HStack(spacing: 20) {
+                    Button(action: {
+                        presentationMode.wrappedValue.dismiss()
+                    }) {
+                        Text("Decline")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .foregroundColor(.red)
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                    }
+                    Button(action: {
+                        onAccept()
+                        presentationMode.wrappedValue.dismiss()
+                    }) {
+                        Text("Accept")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .foregroundColor(.white)
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Terms of Service")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+
+#Preview {
+    TermsOfServiceView()
+}


### PR DESCRIPTION
## Summary
- add TermsOfServiceManager to track user acceptance
- create TermsOfServiceView with service details and buttons
- require terms acceptance before first analysis
- link to full terms from PricingView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688b01ef579483339108ccdd24aef90c