### PR TITLE
Show analysis menu without selecting photos

### DIFF
--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -224,15 +224,13 @@ struct ContentView: View {
     
     @ViewBuilder
     private var criteriaSelectionSection: some View {
-        if !selectedImages.isEmpty {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Analysis Type")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .padding(.horizontal)
-                
-                criteriaGrid
-            }
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Analysis Type")
+                .font(.headline)
+                .fontWeight(.semibold)
+                .padding(.horizontal)
+
+            criteriaGrid
         }
     }
     
@@ -255,33 +253,31 @@ struct ContentView: View {
     
     @ViewBuilder
     private var analysisButtonSection: some View {
-        if !selectedImages.isEmpty {
-            Button(action: analyzePhotos) {
-                HStack {
-                    if isProcessing {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                            .scaleEffect(0.8)
-                    }
-                    
-                    Text(getButtonText())
-                        .fontWeight(.semibold)
+        Button(action: analyzePhotos) {
+            HStack {
+                if isProcessing {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .scaleEffect(0.8)
                 }
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(
-                    LinearGradient(
-                        gradient: Gradient(colors: getButtonColors()),
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                )
-                .cornerRadius(12)
+
+                Text(getButtonText())
+                    .fontWeight(.semibold)
             }
-            .disabled(isAnalysisDisabled)
-            .padding(.horizontal)
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: getButtonColors()),
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .cornerRadius(12)
         }
+        .disabled(isAnalysisDisabled)
+        .padding(.horizontal)
     }
     
     @ViewBuilder


### PR DESCRIPTION
## Summary
- keep the criteria selection grid visible
- always show the analyze button

## Testing
- `swift --version`
- `swift test --disable-sandbox` *(fails: Could not find Package.swift)*
- `npm test --silent` in functions

------
https://chatgpt.com/codex/tasks/task_e_688b093afde883339ce7e77c538cb7fd