### PR TITLE
Align privacy policy with storage behavior

### DIFF
--- a/PhotoRater/Views/PrivacyPolicyView.swift
+++ b/PhotoRater/Views/PrivacyPolicyView.swift
@@ -16,7 +16,7 @@ struct PrivacyPolicyView: View {
                         .font(.body)
 
                     SectionHeader("Storage")
-                    Text("Photos and analysis results are temporarily stored in Firebase to sync across your devices. Data is retained for up to 30 days then automatically deleted.")
+                    Text("Photos you upload are used only for analysis. They are deleted from Firebase immediately after processing, and the analysis results are returned directly to your device without being stored on our servers.")
                         .font(.body)
 
                     SectionHeader("Sharing")


### PR DESCRIPTION
## Summary
- update the privacy policy to clarify that photos are removed from Firebase immediately after processing

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_688b140ccb6483338c888718661bed85