### PR TITLE
Handle offline mode for Firestore

### DIFF
--- a/PhotoRater/Services/NetworkMonitor.swift
+++ b/PhotoRater/Services/NetworkMonitor.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Network
+import Combine
+import FirebaseFirestore
+
+/// Monitors network connectivity so services can avoid failing when offline.
+class NetworkMonitor: ObservableObject {
+    static let shared = NetworkMonitor()
+
+    @Published private(set) var isConnected: Bool = true
+
+    private let monitor: NWPathMonitor
+    private let queue = DispatchQueue(label: "NetworkMonitor")
+
+    private init() {
+        monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            let connected = path.status == .satisfied
+            DispatchQueue.main.async {
+                self?.isConnected = connected
+                if connected {
+                    Firestore.firestore().enableNetwork(completion: nil)
+                } else {
+                    Firestore.firestore().disableNetwork(completion: nil)
+                }
+            }
+        }
+        monitor.start(queue: queue)
+    }
+}

--- a/PhotoRater/Services/PricingManager.swift
+++ b/PhotoRater/Services/PricingManager.swift
@@ -148,6 +148,16 @@ class PricingManager: ObservableObject {
             }
             return
         }
+
+        // Avoid Firestore calls when the device is offline
+        guard NetworkMonitor.shared.isConnected else {
+            await MainActor.run {
+                print("⚠️ Offline - using local free credit defaults")
+                self.freeCredits = self.isLaunchPeriod ? 15 : 3
+                self.updateTotalCredits()
+            }
+            return
+        }
         
         let db = Firestore.firestore()
         


### PR DESCRIPTION
## Summary
- add a `NetworkMonitor` that toggles Firestore networking based on connectivity
- avoid loading free credits from Firestore when offline

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_688b1b342fdc8333869584117b9fd7bf