### PR TITLE
Enable Firebase emulator suite

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -2,6 +2,8 @@ import UIKit
 import FirebaseCore
 import FirebaseAuth
 import FirebaseFirestore
+import FirebaseFunctions
+import FirebaseStorage
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     private var authStateListener: AuthStateDidChangeListenerHandle?
@@ -12,6 +14,18 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         FirebaseApp.configure()
         print("🔥 Firebase configured successfully")
         
+        // Connect to Firebase emulators when enabled
+#if DEBUG
+        if ProcessInfo.processInfo.environment["FIREBASE_EMULATORS"] == "1" {
+            let host = "localhost"
+            Auth.auth().useEmulator(withHost: host, port: 9099)
+            Firestore.firestore().useEmulator(withHost: host, port: 8080)
+            Functions.functions().useEmulator(withHost: host, port: 5001)
+            Storage.storage().useEmulator(withHost: host, port: 9199)
+            print("🔄 Using Firebase emulators")
+        }
+#endif
+
         // Configure Firestore settings for better performance
         configureFirestoreSettings()
         

--- a/PhotoRater/firebase.json
+++ b/PhotoRater/firebase.json
@@ -11,5 +11,11 @@
         "*.local"
       ]
     }
-  ]
+  ],
+  "emulators": {
+    "functions": { "host": "localhost", "port": 5001 },
+    "firestore": { "host": "localhost", "port": 8080 },
+    "auth": { "host": "localhost", "port": 9099 },
+    "storage": { "host": "localhost", "port": 9199 }
+  }
 }


### PR DESCRIPTION
## Summary
- configure Firebase emulators in `firebase.json`
- allow iOS app to connect to local emulators when `FIREBASE_EMULATORS=1`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688b1e84660c8333a7df20dd23c7e004