### PR TITLE
Remove automatic Apple ID sign-in

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -36,7 +36,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 // Initialize user credits after authentication
                 Task {
                     await PricingManager.shared.loadUserCredits()
-                    await PricingManager.shared.restorePurchases()
+                    if PricingManager.shouldAutoRestorePurchases {
+                        await PricingManager.shared.restorePurchases()
+                    }
                 }
             } else {
                 print("🔑 No user authenticated, signing in anonymously...")
@@ -49,7 +51,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                         // Initialize user credits after authentication
                         Task {
                             await PricingManager.shared.loadUserCredits()
-                            await PricingManager.shared.restorePurchases()
+                            if PricingManager.shouldAutoRestorePurchases {
+                                await PricingManager.shared.restorePurchases()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- avoid automatic purchase restoration on launch
- don't attempt to restore purchases automatically after authentication
- make restoration conditional on a simulator check

## Testing
- `npm test` *(fails: Missing script)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bb0c5bc0483339a8b6aac111d4ca1