### PR TITLE
Fix compile-time constant order

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -36,7 +36,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 // Initialize user credits after authentication
                 Task {
                     await PricingManager.shared.loadUserCredits()
-                    await PricingManager.shared.restorePurchases()
+                    if PricingManager.shouldAutoRestorePurchases {
+                        await PricingManager.shared.restorePurchases()
+                    }
                 }
             } else {
                 print("🔑 No user authenticated, signing in anonymously...")
@@ -49,7 +51,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                         // Initialize user credits after authentication
                         Task {
                             await PricingManager.shared.loadUserCredits()
-                            await PricingManager.shared.restorePurchases()
+                            if PricingManager.shouldAutoRestorePurchases {
+                                await PricingManager.shared.restorePurchases()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- move `shouldAutoRestorePurchases` before shared instance creation
- keep conditional restore logic in AppDelegate
- expose flag as computed property so build always sees it

## Testing
- `swift test` inside Firebase package
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688bb0c5bc0483339a8b6aac111d4ca1