### PR TITLE
Fix purchase restoration flag duplication

### DIFF
--- a/PhotoRater/Services/PricingManager.swift
+++ b/PhotoRater/Services/PricingManager.swift
@@ -28,15 +28,6 @@ class PricingManager: ObservableObject {
 
     /// Shared singleton instance
     static let shared = PricingManager()
-
-#if targetEnvironment(simulator)
-    /// Disable automatic purchase restoration on the simulator to avoid the
-    /// Apple ID prompt. Toggle back for App Store builds.
-    static let shouldAutoRestorePurchases = false
-#else
-    /// Enable automatic purchase restoration on physical devices.
-    static let shouldAutoRestorePurchases = true
-#endif
     private var updateListenerTask: Task<Void, Error>?
 
     // MARK: - Product Metadata


### PR DESCRIPTION
## Summary
- remove duplicate `shouldAutoRestorePurchases` constant in `PricingManager`
- keep conditional restoration logic in `AppDelegate`

## Testing
- `swift build` in `Firebase`

------
https://chatgpt.com/codex/tasks/task_e_688bbefd0470833381e79e12e1940394