### PR TITLE
Remove simulator-specific logic

### DIFF
--- a/PhotoRater/App/AppDelegate.swift
+++ b/PhotoRater/App/AppDelegate.swift
@@ -26,9 +26,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 // Initialize user credits after authentication
                 Task {
                     await PricingManager.shared.loadUserCredits()
-                    if PricingManager.shouldAutoRestorePurchases {
-                        await PricingManager.shared.restorePurchases()
-                    }
+                    await PricingManager.shared.restorePurchases()
                 }
             } else {
                 print("🔑 No user authenticated, signing in anonymously...")
@@ -41,9 +39,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                         // Initialize user credits after authentication
                         Task {
                             await PricingManager.shared.loadUserCredits()
-                            if PricingManager.shouldAutoRestorePurchases {
-                                await PricingManager.shared.restorePurchases()
-                            }
+                            await PricingManager.shared.restorePurchases()
                         }
                     }
                 }

--- a/PhotoRater/Services/PricingManager.swift
+++ b/PhotoRater/Services/PricingManager.swift
@@ -16,16 +16,6 @@ class PricingManager: ObservableObject {
     private var purchasedCredits: Int = 0
     private var freeCredits: Int = 0
     
-    // Toggle automatic purchase restoration based on the build environment
-#if targetEnvironment(simulator)
-    /// Disable automatic restoration in the simulator to avoid the Apple ID
-    /// prompt. Switch this back for App Store builds.
-    static let shouldAutoRestorePurchases = false
-#else
-    /// Enable automatic restoration on physical devices.
-    static let shouldAutoRestorePurchases = true
-#endif
-
     /// Shared singleton instance
     static let shared = PricingManager()
     private var updateListenerTask: Task<Void, Error>?
@@ -94,9 +84,7 @@ class PricingManager: ObservableObject {
         
         Task {
             await loadProducts()
-            if PricingManager.shouldAutoRestorePurchases {
-                await restoreAllPurchasesFromApple() // Check Apple first
-            }
+            await restoreAllPurchasesFromApple() // Check Apple first
             await loadFreeCreditsFromFirebase()   // Then load any saved free credits
             await MainActor.run {
                 self.isInitialized = true


### PR DESCRIPTION
## Summary
- remove `shouldAutoRestorePurchases` guard and always restore purchases
- clean `PricingManager` to no longer check for simulator builds

## Testing
- `swift --version`
- `xcodebuild -list -project PhotoRater/PhotoRater.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4535f8c8333bab1ef5d53145fe1