### PR TITLE
Use device-based ID for photo uploads

### DIFF
--- a/PhotoRater/Services/DeviceIdManager.swift
+++ b/PhotoRater/Services/DeviceIdManager.swift
@@ -1,0 +1,45 @@
+import UIKit
+import Security
+
+class DeviceIdManager {
+    static let shared = DeviceIdManager()
+    private let key = "com.photoranker.deviceId"
+
+    private init() {}
+
+    func deviceId() -> String {
+        if let existing = readId() {
+            return existing
+        }
+        let newId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        saveId(newId)
+        return newId
+    }
+
+    private func readId() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data,
+              let id = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return id
+    }
+
+    private func saveId(_ id: String) {
+        let data = id.data(using: .utf8)!
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+}

--- a/PhotoRater/Services/PhotoProcessor.swift
+++ b/PhotoRater/Services/PhotoProcessor.swift
@@ -121,11 +121,7 @@ class PhotoProcessor: ObservableObject {
     }
     
     private func uploadOptimizedPhotos(_ images: [UIImage], completion: @escaping (Result<[String], Error>) -> Void) {
-        guard let userId = Auth.auth().currentUser?.uid else {
-            completion(.failure(NSError(domain: "PhotoProcessor", code: 0,
-                                       userInfo: [NSLocalizedDescriptionKey: "User not authenticated"])))
-            return
-        }
+        let deviceId = DeviceIdManager.shared.deviceId()
         
         let dispatchGroup = DispatchGroup()
         var uploadedUrls: [String] = []
@@ -141,10 +137,10 @@ class PhotoProcessor: ObservableObject {
                 continue
             }
             
-            // SECURITY: User-specific secure file path
+            // SECURITY: Device-specific secure file path
             let timestamp = Int(Date().timeIntervalSince1970)
             let randomId = UUID().uuidString.prefix(8)
-            let fileName = "ai-analysis/\(userId)/\(timestamp)_\(randomId)_\(index).jpg"
+            let fileName = "ai-analysis/\(deviceId)/\(timestamp)_\(randomId)_\(index).jpg"
             let ref = storage.reference().child(fileName)
             
             // Upload optimized image


### PR DESCRIPTION
## Summary
- add `DeviceIdManager` to persist a device identifier
- switch photo upload path to use device-based ID

## Testing
- `swift test --disable-sandbox` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688bcc6dfbdc8333a89968fb3f71d977