### PR TITLE
Add tab navigation for main flows

### DIFF
--- a/PhotoRater/PhotoRankerApp.swift
+++ b/PhotoRater/PhotoRankerApp.swift
@@ -15,7 +15,7 @@ struct PhotoRaterApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
                 .onAppear {
                     // Ensure Firebase is configured
                     if FirebaseApp.app() == nil {

--- a/PhotoRater/Views/MainTabView.swift
+++ b/PhotoRater/Views/MainTabView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct MainTabView: View {
+    enum Tab {
+        case analyze
+        case pricing
+        case promo
+    }
+
+    @State private var selectedTab: Tab = .analyze
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            ContentView()
+                .tabItem {
+                    Label("Analyze", systemImage: "sparkles.magnifyingglass")
+                }
+                .tag(Tab.analyze)
+
+            PricingView()
+                .tabItem {
+                    Label("Credits", systemImage: "bolt.fill")
+                }
+                .tag(Tab.pricing)
+
+            PromoCodeView()
+                .tabItem {
+                    Label("Promo", systemImage: "ticket.fill")
+                }
+                .tag(Tab.promo)
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+}


### PR DESCRIPTION
## Summary
- add `MainTabView` hosting analysis, credits and promo code tabs
- start the app with `MainTabView` instead of `ContentView`

## Testing
- `swift test -c release` *(fails: `Could not find Package.swift`)*
- `xcodebuild -list` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688d2e37e77083338a648de10e30044f