### PR TITLE
Fix missing photo display in analysis results

### DIFF
--- a/PhotoRater/Services/PhotoProcessor.swift
+++ b/PhotoRater/Services/PhotoProcessor.swift
@@ -444,7 +444,7 @@ class PhotoProcessor: ObservableObject {
                     }
                 }
                 
-                let rankedPhoto = RankedPhoto(
+                var rankedPhoto = RankedPhoto(
                     id: UUID(),
                     fileName: fileName,
                     storageURL: storageURL,
@@ -458,7 +458,13 @@ class PhotoProcessor: ObservableObject {
                     strengths: strengths,
                     nextPhotoSuggestions: nextPhotoSuggestions
                 )
-                
+
+                if let indexString = fileName.split(separator: "_").last,
+                   let index = Int(indexString),
+                   index < originalImages.count {
+                    rankedPhoto.localImage = originalImages[index]
+                }
+
                 rankedPhotos.append(rankedPhoto)
             }
             


### PR DESCRIPTION
## Summary
- return each photo's index from `analyzePhotos` so that results can be matched to images
- assign `localImage` in `PhotoProcessor` using the index from the returned file name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d65de37188333b682b466700b88b0