### PR TITLE
Display analyzed photos next to results

### DIFF
--- a/PhotoRater/Services/PhotoProcessor.swift
+++ b/PhotoRater/Services/PhotoProcessor.swift
@@ -444,7 +444,7 @@ class PhotoProcessor: ObservableObject {
                     }
                 }
                 
-                let rankedPhoto = RankedPhoto(
+                var rankedPhoto = RankedPhoto(
                     id: UUID(),
                     fileName: fileName,
                     storageURL: storageURL,
@@ -458,7 +458,14 @@ class PhotoProcessor: ObservableObject {
                     strengths: strengths,
                     nextPhotoSuggestions: nextPhotoSuggestions
                 )
-                
+
+                // Attach the originally selected image so the UI can display it
+                if let indexString = fileName.split(separator: "_").last,
+                   let index = Int(indexString),
+                   index < originalImages.count {
+                    rankedPhoto.localImage = originalImages[index]
+                }
+
                 rankedPhotos.append(rankedPhoto)
             }
             


### PR DESCRIPTION
## Summary
- Attach original images to each analysis result so the UI can show photos alongside AI feedback.

## Testing
- `swift --version`
- `cd PhotoRater && swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d6b27d4d48333af267efca42be441