### PR TITLE
Add gallery and account tabs with photo saving

### DIFF
--- a/PhotoRater/Models/GalleryProfile.swift
+++ b/PhotoRater/Models/GalleryProfile.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SwiftUI
+
+struct GalleryProfile: Identifiable {
+    let id: UUID = UUID()
+    var name: String
+    var photos: [RankedPhoto] = []
+}

--- a/PhotoRater/PhotoRankerApp.swift
+++ b/PhotoRater/PhotoRankerApp.swift
@@ -16,6 +16,7 @@ struct PhotoRaterApp: App {
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .environmentObject(GalleryManager.shared)
                 .onAppear {
                     // Ensure Firebase is configured
                     if FirebaseApp.app() == nil {

--- a/PhotoRater/Services/GalleryManager.swift
+++ b/PhotoRater/Services/GalleryManager.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftUI
+
+class GalleryManager: ObservableObject {
+    static let shared = GalleryManager()
+    @Published var profiles: [GalleryProfile]
+
+    init() {
+        self.profiles = [GalleryProfile(name: "Default")]
+    }
+
+    func addProfile(named name: String) {
+        guard !name.isEmpty else { return }
+        profiles.append(GalleryProfile(name: name))
+    }
+
+    func addPhoto(_ photo: RankedPhoto, to profile: GalleryProfile? = nil) {
+        if let profile = profile, let index = profiles.firstIndex(where: { $0.id == profile.id }) {
+            profiles[index].photos.append(photo)
+        } else {
+            profiles[0].photos.append(photo)
+        }
+    }
+
+    func movePhoto(at offsets: IndexSet, to destination: Int, in profile: GalleryProfile) {
+        guard let index = profiles.firstIndex(where: { $0.id == profile.id }) else { return }
+        profiles[index].photos.move(fromOffsets: offsets, toOffset: destination)
+    }
+}

--- a/PhotoRater/Views/AccountView.swift
+++ b/PhotoRater/Views/AccountView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct AccountView: View {
+    var body: some View {
+        NavigationView {
+            List {
+                NavigationLink("Credits", destination: PricingView())
+                NavigationLink("Promo Code", destination: PromoCodeView())
+                NavigationLink("Privacy Policy", destination: PrivacyPolicyView())
+            }
+            .navigationTitle("Account")
+        }
+    }
+}

--- a/PhotoRater/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater/Views/Components/PhotoResultCard.swift
@@ -5,6 +5,7 @@ struct PhotoResultCard: View {
     @State private var isLoading = true
     @State private var loadedImage: UIImage?
     @State private var showingDetailView = false
+    @EnvironmentObject var gallery: GalleryManager
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -106,6 +107,34 @@ struct PhotoResultCard: View {
                     )
                 }
                 .buttonStyle(PlainButtonStyle()) // Ensures reliable tapping
+
+                Button(action: {
+                    gallery.addPhoto(rankedPhoto)
+                }) {
+                    HStack {
+                        Image(systemName: "tray.and.arrow.down")
+                            .font(.subheadline)
+                        Text("Save to Gallery")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Image(systemName: "plus")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .foregroundColor(.green)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.green.opacity(0.1))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.green.opacity(0.3), lineWidth: 1)
+                            )
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
             }
             .padding(.horizontal, 12)
             .padding(.bottom, 12)

--- a/PhotoRater/Views/GalleryView.swift
+++ b/PhotoRater/Views/GalleryView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct GalleryView: View {
+    @EnvironmentObject var gallery: GalleryManager
+    @State private var newProfile = ""
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                HStack {
+                    TextField("New profile", text: $newProfile)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    Button("Add") {
+                        gallery.addProfile(named: newProfile)
+                        newProfile = ""
+                    }
+                }
+                .padding()
+
+                List {
+                    ForEach(gallery.profiles) { profile in
+                        NavigationLink(destination: ProfileDetailView(profile: profile)) {
+                            Text(profile.name)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Gallery")
+        }
+    }
+}

--- a/PhotoRater/Views/MainTabView.swift
+++ b/PhotoRater/Views/MainTabView.swift
@@ -2,32 +2,32 @@ import SwiftUI
 
 struct MainTabView: View {
     enum Tab {
-        case analyze
-        case pricing
-        case promo
+        case analysis
+        case gallery
+        case account
     }
 
-    @State private var selectedTab: Tab = .analyze
+    @State private var selectedTab: Tab = .analysis
 
     var body: some View {
         TabView(selection: $selectedTab) {
             ContentView()
                 .tabItem {
-                    Label("Analyze", systemImage: "sparkles.magnifyingglass")
+                    Label("Analysis", systemImage: "sparkles.magnifyingglass")
                 }
-                .tag(Tab.analyze)
+                .tag(Tab.analysis)
 
-            PricingView()
+            GalleryView()
                 .tabItem {
-                    Label("Credits", systemImage: "bolt.fill")
+                    Label("Gallery", systemImage: "photo.on.rectangle.angled")
                 }
-                .tag(Tab.pricing)
+                .tag(Tab.gallery)
 
-            PromoCodeView()
+            AccountView()
                 .tabItem {
-                    Label("Promo", systemImage: "ticket.fill")
+                    Label("Account", systemImage: "person.crop.circle")
                 }
-                .tag(Tab.promo)
+                .tag(Tab.account)
         }
     }
 }

--- a/PhotoRater/Views/PrivacyPolicyView.swift
+++ b/PhotoRater/Views/PrivacyPolicyView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    var body: some View {
+        ScrollView {
+            Text("Your privacy policy goes here.")
+                .padding()
+        }
+        .navigationTitle("Privacy Policy")
+    }
+}

--- a/PhotoRater/Views/ProfileDetailView.swift
+++ b/PhotoRater/Views/ProfileDetailView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct ProfileDetailView: View {
+    @EnvironmentObject var gallery: GalleryManager
+    var profile: GalleryProfile
+
+    var body: some View {
+        if let index = gallery.profiles.firstIndex(where: { $0.id == profile.id }) {
+            let binding = $gallery.profiles[index]
+            List {
+                ForEach(binding.photos) { photo in
+                    HStack {
+                        if let image = photo.localImage {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 80, height: 80)
+                                .clipped()
+                        } else {
+                            Rectangle()
+                                .fill(Color.gray.opacity(0.3))
+                                .frame(width: 80, height: 80)
+                        }
+                        Text(photo.fileName)
+                            .lineLimit(1)
+                    }
+                }
+                .onMove { offsets, dest in
+                    gallery.movePhoto(at: offsets, to: dest, in: binding.wrappedValue)
+                }
+            }
+            .navigationTitle(binding.wrappedValue.name)
+            .toolbar { EditButton() }
+        } else {
+            Text("Profile not found")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce GalleryManager and GalleryProfile to manage saved analyses
- add Gallery and Account tabs alongside existing Analysis tab
- allow saving analysis results to gallery and reordering within named profiles

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d6cbadb9c8333889b1a5864672395