### PR TITLE
Fix zero-score parsing in Firebase functions

### DIFF
--- a/PhotoRater/functions/index.js
+++ b/PhotoRater/functions/index.js
@@ -464,11 +464,11 @@ function parseEnhancedAIResponse(responseText, criteria, fileName, photoUrl) {
       return {
         fileName: fileName,
         storageURL: photoUrl,
-        score: Math.min(Math.max(parsed.score || 75, 0), 100),
-        visualQuality: Math.min(Math.max(parsed.visualQuality || parsed.score || 75, 0), 100),
-        attractivenessScore: Math.min(Math.max(parsed.attractivenessScore || parsed.score || 75, 0), 100),
-        datingAppealScore: Math.min(Math.max(parsed.datingAppealScore || parsed.score || 75, 0), 100),
-        swipeWorthiness: Math.min(Math.max(parsed.swipeWorthiness || parsed.score || 75, 0), 100),
+        score: Math.min(Math.max(parsed.score ?? 75, 0), 100),
+        visualQuality: Math.min(Math.max(parsed.visualQuality ?? parsed.score ?? 75, 0), 100),
+        attractivenessScore: Math.min(Math.max(parsed.attractivenessScore ?? parsed.score ?? 75, 0), 100),
+        datingAppealScore: Math.min(Math.max(parsed.datingAppealScore ?? parsed.score ?? 75, 0), 100),
+        swipeWorthiness: Math.min(Math.max(parsed.swipeWorthiness ?? parsed.score ?? 75, 0), 100),
         
         // Basic fields
         tags: Array.isArray(parsed.tags) ? parsed.tags : [],
@@ -524,6 +524,9 @@ function parseEnhancedAIResponse(responseText, criteria, fileName, photoUrl) {
   console.log(`JSON parsing failed for ${criteria}, using enhanced fallback parsing`);
   return createEnhancedFallbackResponse(fileName, photoUrl, criteria, responseText);
 }
+
+// Export for testing
+exports.parseEnhancedAIResponse = parseEnhancedAIResponse;
 
 // ENHANCED FALLBACK RESPONSES
 function createEnhancedFallbackResponse(fileName, photoUrl, criteria, responseText = '') {

--- a/PhotoRater/functions/package.json
+++ b/PhotoRater/functions/package.json
@@ -6,7 +6,8 @@
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "node --test test/parseEnhancedAIResponse.test.js"
   },
   "engines": {
     "node": "22"

--- a/PhotoRater/functions/test/parseEnhancedAIResponse.test.js
+++ b/PhotoRater/functions/test/parseEnhancedAIResponse.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { parseEnhancedAIResponse } = require('../index.js');
+
+test('keeps zero scores instead of defaulting', () => {
+  const responseText = JSON.stringify({
+    score: 0,
+    visualQuality: 0,
+    attractivenessScore: 0,
+    datingAppealScore: 0,
+    swipeWorthiness: 0
+  });
+  const result = parseEnhancedAIResponse(responseText, 'best', 'photo_0', '');
+  assert.strictEqual(result.score, 0);
+  assert.strictEqual(result.visualQuality, 0);
+  assert.strictEqual(result.attractivenessScore, 0);
+  assert.strictEqual(result.datingAppealScore, 0);
+  assert.strictEqual(result.swipeWorthiness, 0);
+});


### PR DESCRIPTION
## Summary
- preserve 0-valued scores when parsing AI responses
- expose `parseEnhancedAIResponse` for tests and add regression test
- add npm test script for functions package

## Testing
- `npm test`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688d737e7c388333a1124e65bcd9cdce