### PR TITLE
fix: correct profile detail view binding

### DIFF
--- a/PhotoRater/Views/ProfileDetailView.swift
+++ b/PhotoRater/Views/ProfileDetailView.swift
@@ -6,9 +6,9 @@ struct ProfileDetailView: View {
 
     var body: some View {
         if let index = gallery.profiles.firstIndex(where: { $0.id == profile.id }) {
-            let binding = $gallery.profiles[index]
+            let currentProfile = gallery.profiles[index]
             List {
-                ForEach(binding.photos) { photo in
+                ForEach(currentProfile.photos) { photo in
                     HStack {
                         if let image = photo.localImage {
                             Image(uiImage: image)
@@ -26,10 +26,10 @@ struct ProfileDetailView: View {
                     }
                 }
                 .onMove { offsets, dest in
-                    gallery.movePhoto(at: offsets, to: dest, in: binding.wrappedValue)
+                    gallery.movePhoto(at: offsets, to: dest, in: currentProfile)
                 }
             }
-            .navigationTitle(binding.wrappedValue.name)
+            .navigationTitle(currentProfile.name)
             .toolbar { EditButton() }
         } else {
             Text("Profile not found")


### PR DESCRIPTION
## Summary
- remove unsupported environment object binding in `ProfileDetailView`
- iterate photos directly from stored profile and move photos using `GalleryManager`

## Testing
- `npm test` (`PhotoRater/functions`)
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688edb58ce68833386e9a4558df6aca6