### PR TITLE
Allow re-analysis when changing categories

### DIFF
--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -315,6 +315,10 @@ struct ContentView: View {
             }
         }
         .navigationViewStyle(.stack)
+        // Clear previous results when switching analysis criteria
+        .onChange(of: selectedCriteria) { _ in
+            rankedPhotos = []
+        }
     }
     
     // MARK: - Computed Properties


### PR DESCRIPTION
## Summary
- Clear previously ranked photos when the user selects a new analysis category so they can analyze again without re-uploading images.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ee06cde6083338d2d3e14319c25dc