### PR TITLE
Automatically save analyzed photos to gallery

### DIFF
--- a/PhotoRater/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater/Views/Components/PhotoResultCard.swift
@@ -5,7 +5,6 @@ struct PhotoResultCard: View {
     @State private var isLoading = true
     @State private var loadedImage: UIImage?
     @State private var showingDetailView = false
-    @EnvironmentObject var gallery: GalleryManager
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -108,33 +107,26 @@ struct PhotoResultCard: View {
                 }
                 .buttonStyle(PlainButtonStyle()) // Ensures reliable tapping
 
-                Button(action: {
-                    gallery.addPhoto(rankedPhoto)
-                }) {
-                    HStack {
-                        Image(systemName: "tray.and.arrow.down")
-                            .font(.subheadline)
-                        Text("Save to Gallery")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                        Spacer()
-                        Image(systemName: "plus")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .foregroundColor(.green)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.green.opacity(0.1))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color.green.opacity(0.3), lineWidth: 1)
-                            )
-                    )
+                // Display that the photo has been saved automatically
+                HStack {
+                    Image(systemName: "tray.and.arrow.down.fill")
+                        .font(.subheadline)
+                    Text("Saved to Gallery")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Spacer()
                 }
-                .buttonStyle(PlainButtonStyle())
+                .foregroundColor(.green)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.green.opacity(0.1))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.green.opacity(0.3), lineWidth: 1)
+                        )
+                )
             }
             .padding(.horizontal, 12)
             .padding(.bottom, 12)

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -450,6 +450,10 @@ struct ContentView: View {
                 switch result {
                 case .success(let rankedPhotos):
                     self.rankedPhotos = rankedPhotos
+                    // Automatically save analyzed photos to the gallery
+                    for photo in rankedPhotos {
+                        GalleryManager.shared.addPhoto(photo)
+                    }
                     self.pricingManager.deductCredits(count: photoCount)
                 case .failure(let error):
                     if error.localizedDescription.contains("Insufficient credits") {


### PR DESCRIPTION
## Summary
- Automatically persist analysis results to the gallery.
- Replace manual gallery save button with visual confirmation that photos are saved.

## Testing
- `npm test` *(fails: parseEnhancedAIResponse is not a function)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688eebca795c8333bb4e536c951fb3a2