### PR TITLE
Fix gallery images to stay within set frames

### DIFF
--- a/PhotoRater/Views/Components/GalleryPhotoCard.swift
+++ b/PhotoRater/Views/Components/GalleryPhotoCard.swift
@@ -66,6 +66,7 @@ struct GalleryPhotoCard: View {
             }
         }
         .padding(.bottom, 12)
+        .frame(maxWidth: .infinity)
         .background(Color(.systemBackground))
         .cornerRadius(12)
         .shadow(color: Color.black.opacity(0.1), radius: 3, x: 0, y: 1)
@@ -84,7 +85,7 @@ struct GalleryPhotoCard: View {
                     .scaledToFill()
             } else if isLoading {
                 ProgressView()
-                    .frame(height: 180)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 Rectangle()
                     .fill(Color.gray.opacity(0.3))
@@ -95,7 +96,8 @@ struct GalleryPhotoCard: View {
                     )
             }
         }
-        .frame(height: 180)
+        .frame(maxWidth: .infinity)
+        .aspectRatio(1, contentMode: .fill)
         .clipped()
         .cornerRadius(12)
     }


### PR DESCRIPTION
## Summary
- constrain gallery cards to available width
- make gallery images square to stop overlap and cropping issues

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688ef17dd2a883339753512918a0bb20