### PR TITLE
Fix detailed analysis button presentation

### DIFF
--- a/PhotoRater/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater/Views/Components/PhotoResultCard.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 struct PhotoResultCard: View {
     let rankedPhoto: RankedPhoto
+    let onViewDetails: () -> Void
     @State private var isLoading = true
     @State private var loadedImage: UIImage?
-    @State private var showingDetailView = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -100,9 +100,7 @@ struct PhotoResultCard: View {
                 )
 
                 // Details button placed at bottom for clearer tap target
-                Button(action: {
-                    showingDetailView = true
-                }) {
+                Button(action: onViewDetails) {
                     HStack {
                         Image(systemName: "info.circle.fill")
                             .font(.subheadline)
@@ -138,9 +136,6 @@ struct PhotoResultCard: View {
         .shadow(color: Color.black.opacity(0.1), radius: 3, x: 0, y: 1)
         .onAppear {
             loadImageFromURL()
-        }
-        .sheet(isPresented: $showingDetailView) {
-            PhotoDetailView(rankedPhoto: rankedPhoto)
         }
     }
     

--- a/PhotoRater/Views/ContentView.swift
+++ b/PhotoRater/Views/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var errorMessage: String? = nil
     @State private var showingAlert = false
     @State private var alertMessage = ""
+    @State private var selectedPhotoForDetail: RankedPhoto?
     
     @StateObject private var pricingManager = PricingManager.shared
     
@@ -271,8 +272,10 @@ struct ContentView: View {
                             // Single column of photo cards
                             VStack(spacing: 16) {
                                 ForEach(rankedPhotos) { photo in
-                                    PhotoResultCard(rankedPhoto: photo)
-                                        .padding(.horizontal)
+                                    PhotoResultCard(rankedPhoto: photo, onViewDetails: {
+                                        selectedPhotoForDetail = photo
+                                    })
+                                    .padding(.horizontal)
                                 }
                             }
                         }
@@ -290,6 +293,9 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showingPromoCodeView) {
                 PromoCodeView()
+            }
+            .sheet(item: $selectedPhotoForDetail) { photo in
+                PhotoDetailView(rankedPhoto: photo)
             }
             .alert("Error", isPresented: $showingAlert) {
                 Button("OK") {

--- a/PhotoRater_backup/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater_backup/Views/Components/PhotoResultCard.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 struct PhotoResultCard: View {
     let rankedPhoto: RankedPhoto
+    let onViewDetails: () -> Void
     @State private var isLoading = true
     @State private var loadedImage: UIImage?
-    @State private var showingDetailView = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -79,9 +79,7 @@ struct PhotoResultCard: View {
                 }
                 
                 // IMPROVED DETAILS BUTTON - Much more prominent and reliable
-                Button(action: {
-                    showingDetailView = true
-                }) {
+                Button(action: onViewDetails) {
                     HStack {
                         Image(systemName: "info.circle.fill")
                             .font(.subheadline)
@@ -115,9 +113,6 @@ struct PhotoResultCard: View {
         .shadow(color: Color.black.opacity(0.1), radius: 3, x: 0, y: 1)
         .onAppear {
             loadImageFromURL()
-        }
-        .sheet(isPresented: $showingDetailView) {
-            PhotoDetailView(rankedPhoto: rankedPhoto)
         }
     }
     

--- a/PhotoRater_backup/Views/ContentView.swift
+++ b/PhotoRater_backup/Views/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var errorMessage: String? = nil
     @State private var showingAlert = false
     @State private var alertMessage = ""
+    @State private var selectedPhotoForDetail: RankedPhoto?
     
     @StateObject private var pricingManager = PricingManager.shared
     
@@ -271,8 +272,10 @@ struct ContentView: View {
                             // Single column of photo cards
                             VStack(spacing: 16) {
                                 ForEach(rankedPhotos) { photo in
-                                    PhotoResultCard(rankedPhoto: photo)
-                                        .padding(.horizontal)
+                                    PhotoResultCard(rankedPhoto: photo, onViewDetails: {
+                                        selectedPhotoForDetail = photo
+                                    })
+                                    .padding(.horizontal)
                                 }
                             }
                         }
@@ -290,6 +293,9 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showingPromoCodeView) {
                 PromoCodeView()
+            }
+            .sheet(item: $selectedPhotoForDetail) { photo in
+                PhotoDetailView(rankedPhoto: photo)
             }
             .alert("Error", isPresented: $showingAlert) {
                 Button("OK") {


### PR DESCRIPTION
## Summary
- Present detailed photo analysis from `ContentView` to avoid per-card sheet conflicts.
- Replace internal state in `PhotoResultCard` with `onViewDetails` callback for a reliable button tap.

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `npm test --prefix PhotoRater/functions` *(fails: parseEnhancedAIResponse is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688ef58f158c833386b1dfc90e368070