### PR TITLE
fix: preserve zero scores in AI response parsing

### DIFF
--- a/PhotoRater/functions/index.js
+++ b/PhotoRater/functions/index.js
@@ -405,11 +405,11 @@ function parseEnhancedPracticalResponse(responseText, criteria, fileName, photoU
       const result = {  
         fileName: fileName,
         storageURL: photoUrl,
-        score: Math.min(Math.max(parsed.overallScore || parsed.score || 75, 0), 100),
-        visualQuality: Math.min(Math.max(parsed.visualQuality || 75, 0), 100),
-        attractivenessScore: Math.min(Math.max(parsed.attractivenessScore || 75, 0), 100),
-        datingAppealScore: Math.min(Math.max(parsed.datingAppealScore || 75, 0), 100),
-        swipeWorthiness: Math.min(Math.max(parsed.swipeWorthiness || 75, 0), 100),
+        score: Math.min(Math.max(parsed.overallScore ?? parsed.score ?? 75, 0), 100),
+        visualQuality: Math.min(Math.max(parsed.visualQuality ?? 75, 0), 100),
+        attractivenessScore: Math.min(Math.max(parsed.attractivenessScore ?? 75, 0), 100),
+        datingAppealScore: Math.min(Math.max(parsed.datingAppealScore ?? 75, 0), 100),
+        swipeWorthiness: Math.min(Math.max(parsed.swipeWorthiness ?? 75, 0), 100),
         
         tags: Array.isArray(parsed.tags) ? parsed.tags : [],
         
@@ -472,6 +472,12 @@ function parseEnhancedPracticalResponse(responseText, criteria, fileName, photoU
   console.log(`JSON parsing failed for ${criteria}, using enhanced practical fallback parsing`);
   return createEnhancedPracticalFallback(fileName, photoUrl, criteria, responseText);
 }
+
+function parseEnhancedAIResponse(responseText, criteria, fileName, photoUrl) {
+  return parseEnhancedPracticalResponse(responseText, criteria, fileName, photoUrl);
+}
+
+exports.parseEnhancedAIResponse = parseEnhancedAIResponse;
 
 // INTELLIGENT CATEGORIZATION INFERENCE
 function inferCategorizationFromContent(parsed, responseText) {


### PR DESCRIPTION
## Summary
- ensure AI response parser doesn't treat zero values as missing
- export parseEnhancedAIResponse helper for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688efa44582c8333b0bf6deee012fa2b