### PR TITLE
Refine Detailed Analysis button tap area

### DIFF
--- a/PhotoRater/Views/Components/PhotoResultCard.swift
+++ b/PhotoRater/Views/Components/PhotoResultCard.swift
@@ -112,21 +112,21 @@ struct PhotoResultCard: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
-                    .frame(maxWidth: .infinity)
-                    .contentShape(Rectangle())
-                    .foregroundColor(.blue)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.blue.opacity(0.1))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color.blue.opacity(0.3), lineWidth: 1)
-                            )
-                    )
                 }
-                .buttonStyle(PlainButtonStyle()) // Ensures reliable tapping
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .foregroundColor(.blue)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.blue.opacity(0.1))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                        )
+                )
             }
             .padding(.horizontal, 12)
             .padding(.bottom, 12)


### PR DESCRIPTION
## Summary
- Refactor the "View Detailed Analysis" button so the entire control is tappable and uses a plain button style for reliability

## Testing
- `npm test`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6891226293fc83338df92fd655457f81